### PR TITLE
feat(cli): implement comprehensive Django-inspired CLI

### DIFF
--- a/packages/dartango_cli/bin/dartango.dart
+++ b/packages/dartango_cli/bin/dartango.dart
@@ -1,3 +1,16 @@
-void main(List<String> arguments) {
-  // CLI implementation
+#!/usr/bin/env dart
+
+import 'dart:io';
+import 'package:dartango_cli/src/cli_runner.dart';
+
+Future<void> main(List<String> arguments) async {
+  final runner = CliRunner();
+  
+  try {
+    final exitCode = await runner.run(arguments);
+    exit(exitCode);
+  } catch (e) {
+    stderr.writeln('Error: $e');
+    exit(1);
+  }
 }

--- a/packages/dartango_cli/lib/src/cli_runner.dart
+++ b/packages/dartango_cli/lib/src/cli_runner.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+
+import 'commands/create_project.dart';
+import 'commands/start_app.dart';
+import 'commands/generate.dart';
+import 'commands/serve.dart';
+import 'commands/build.dart';
+import 'commands/test.dart' as cli_test;
+import 'commands/doctor.dart';
+
+class CliRunner {
+  late final CommandManager _commandManager;
+  late final ArgParser _argParser;
+
+  CliRunner() {
+    _commandManager = CommandManager();
+    _setupCommands();
+    _setupArgParser();
+  }
+
+  void _setupCommands() {
+    _commandManager.registerAll([
+      CreateProjectCommand(),
+      StartAppCommand(),
+      GenerateCommand(),
+      ServeCommand(),
+      BuildCommand(),
+      cli_test.TestCommand(),
+      DoctorCommand(),
+    ]);
+  }
+
+  void _setupArgParser() {
+    _argParser = ArgParser();
+    _argParser.addFlag('help', abbr: 'h', help: 'Show help information');
+    _argParser.addFlag('version', abbr: 'v', help: 'Show version information');
+    _argParser.addFlag('verbose', help: 'Enable verbose logging');
+  }
+
+  Future<int> run(List<String> arguments) async {
+    try {
+      final results = _argParser.parse(arguments);
+      
+      if (results['help'] as bool) {
+        _showHelp();
+        return 0;
+      }
+      
+      if (results['version'] as bool) {
+        _showVersion();
+        return 0;
+      }
+      
+      if (results.rest.isEmpty) {
+        _showHelp();
+        return 1;
+      }
+      
+      final commandName = results.rest[0];
+      final commandArgs = results.rest.sublist(1);
+      
+      await _commandManager.run([commandName, ...commandArgs]);
+      return 0;
+    } on FormatException catch (e) {
+      stderr.writeln('Error: ${e.message}');
+      _showHelp();
+      return 1;
+    } catch (e) {
+      stderr.writeln('Error: $e');
+      return 1;
+    }
+  }
+
+  void _showHelp() {
+    print('Dartango CLI - Django-inspired framework for Dart');
+    print('');
+    print('Usage: dartango <command> [arguments]');
+    print('');
+    print('Global options:');
+    print('  -h, --help       Show this help information');
+    print('  -v, --version    Show version information');
+    print('  --verbose        Enable verbose logging');
+    print('');
+    print('Available commands:');
+    print('');
+    
+    final commands = _commandManager.commands;
+    final maxNameLength = commands.fold(0, (max, cmd) => 
+        cmd.name.length > max ? cmd.name.length : max);
+    
+    for (final command in commands) {
+      final name = command.name.padRight(maxNameLength);
+      print('  $name  ${command.description}');
+    }
+    
+    print('');
+    print('Run "dartango help <command>" for more information about a command.');
+  }
+
+  void _showVersion() {
+    print('Dartango CLI version 0.0.1');
+    print('Dart SDK version: ${Platform.version}');
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/build.dart
+++ b/packages/dartango_cli/lib/src/commands/build.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+
+class BuildCommand extends Command {
+  @override
+  String get name => 'build';
+
+  @override
+  String get description => 'Build the project for production';
+
+  @override
+  String get help => '''
+Build the Dartango project for production deployment.
+
+This command compiles the project and optimizes it for production use.
+It creates a build directory with all necessary files for deployment.
+
+Examples:
+  dartango build
+  dartango build --output=dist
+  dartango build --mode=release
+  dartango build --verbose
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('output', abbr: 'o', defaultsTo: 'build',
+        help: 'Output directory for build files');
+    parser.addOption('mode', abbr: 'm', defaultsTo: 'release',
+        allowed: ['debug', 'release'],
+        help: 'Build mode');
+    parser.addFlag('verbose', abbr: 'v', defaultsTo: false,
+        help: 'Enable verbose output');
+    parser.addFlag('clean', abbr: 'c', defaultsTo: false,
+        help: 'Clean build directory before building');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (!_isInDartangoProject()) {
+      printError('This command must be run from within a Dartango project');
+      return;
+    }
+
+    final output = args['output'] as String;
+    final mode = args['mode'] as String;
+    final verbose = args['verbose'] as bool;
+    final clean = args['clean'] as bool;
+
+    final buildDir = Directory(output);
+
+    if (clean && await buildDir.exists()) {
+      printInfo('Cleaning build directory...');
+      await buildDir.delete(recursive: true);
+    }
+
+    if (!await buildDir.exists()) {
+      await buildDir.create(recursive: true);
+    }
+
+    printInfo('Building Dartango project...');
+    printInfo('Output directory: $output');
+    printInfo('Build mode: $mode');
+    print('');
+
+    try {
+      // Run dart compile
+      final compileArgs = [
+        'compile',
+        'exe',
+        'bin/main.dart',
+        '-o',
+        '$output/app',
+      ];
+
+      if (mode == 'release') {
+        compileArgs.add('--optimize');
+      }
+
+      final compileProcess = await Process.start(
+        'dart',
+        compileArgs,
+        mode: verbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
+      );
+
+      final compileExitCode = await compileProcess.exitCode;
+
+      if (compileExitCode != 0) {
+        printError('Compilation failed with exit code $compileExitCode');
+        return;
+      }
+
+      // Copy static assets
+      await _copyStaticAssets(output);
+
+      // Generate deployment configuration
+      await _generateDeploymentConfig(output, mode);
+
+      printSuccess('Build completed successfully!');
+      print('');
+      print('Build artifacts:');
+      print('  Executable: $output/app');
+      print('  Static files: $output/static/');
+      print('  Configuration: $output/config.yaml');
+      print('');
+      print('To deploy, copy the $output directory to your server.');
+    } catch (e) {
+      printError('Build failed: $e');
+    }
+  }
+
+  Future<void> _copyStaticAssets(String outputDir) async {
+    final staticDir = Directory('static');
+    if (!await staticDir.exists()) return;
+
+    final outputStaticDir = Directory('$outputDir/static');
+    if (!await outputStaticDir.exists()) {
+      await outputStaticDir.create(recursive: true);
+    }
+
+    await for (final entity in staticDir.list(recursive: true)) {
+      if (entity is File) {
+        final relativePath = entity.path.replaceFirst('static/', '');
+        final outputPath = '$outputDir/static/$relativePath';
+        final outputFile = File(outputPath);
+        
+        await outputFile.create(recursive: true);
+        await entity.copy(outputPath);
+      }
+    }
+  }
+
+  Future<void> _generateDeploymentConfig(String outputDir, String mode) async {
+    final configFile = File('$outputDir/config.yaml');
+    final config = '''
+# Dartango Deployment Configuration
+mode: $mode
+server:
+  host: 0.0.0.0
+  port: 8000
+database:
+  # Configure your database connection here
+  type: sqlite
+  path: data/app.db
+logging:
+  level: ${mode == 'debug' ? 'debug' : 'info'}
+  file: logs/app.log
+''';
+
+    await configFile.writeAsString(config);
+  }
+
+  bool _isInDartangoProject() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return false;
+    
+    final content = pubspecFile.readAsStringSync();
+    return content.contains('dartango');
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/create_project.dart
+++ b/packages/dartango_cli/lib/src/commands/create_project.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+import 'package:path/path.dart' as path;
+
+import '../generators/project_generator.dart';
+
+class CreateProjectCommand extends Command {
+  @override
+  String get name => 'create';
+
+  @override
+  String get description => 'Create a new Dartango project';
+
+  @override
+  String get help => '''
+Create a new Dartango project with the specified name.
+
+This command creates a new project directory with the following structure:
+- lib/: Main application code
+- bin/: Executable entry point
+- test/: Test files
+- pubspec.yaml: Dart package configuration
+- README.md: Project documentation
+
+Examples:
+  dartango create my_project
+  dartango create my_project --template=minimal
+  dartango create my_project --output=/path/to/projects
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('template', abbr: 't', defaultsTo: 'default',
+        allowed: ['default', 'minimal', 'api-only'],
+        help: 'Template to use for the project');
+    parser.addOption('output', abbr: 'o', defaultsTo: '.',
+        help: 'Output directory for the project');
+    parser.addFlag('force', abbr: 'f', defaultsTo: false,
+        help: 'Overwrite existing project directory');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (args.rest.isEmpty) {
+      printError('Project name is required');
+      printInfo('Usage: dartango create <project_name>');
+      return;
+    }
+
+    final projectName = args.rest[0];
+    final template = args['template'] as String;
+    final outputDir = args['output'] as String;
+    final force = args['force'] as bool;
+
+    if (!_isValidProjectName(projectName)) {
+      printError('Invalid project name: $projectName');
+      printInfo('Project name must contain only letters, numbers, and underscores');
+      return;
+    }
+
+    final projectPath = path.join(outputDir, projectName);
+    final projectDir = Directory(projectPath);
+
+    if (await projectDir.exists()) {
+      if (!force) {
+        printError('Project directory already exists: $projectPath');
+        printInfo('Use --force to overwrite existing directory');
+        return;
+      }
+      
+      if (!confirm('Directory "$projectPath" already exists. Overwrite?')) {
+        printInfo('Project creation cancelled');
+        return;
+      }
+      
+      await projectDir.delete(recursive: true);
+    }
+
+    printInfo('Creating Dartango project: $projectName');
+    printInfo('Template: $template');
+    printInfo('Output directory: $projectPath');
+
+    try {
+      final generator = ProjectGenerator(
+        projectName: projectName,
+        template: template,
+        outputPath: projectPath,
+      );
+
+      await generator.generate();
+      
+      printSuccess('Project created successfully!');
+      print('');
+      print('Next steps:');
+      print('  cd $projectName');
+      print('  dart pub get');
+      print('  dartango serve');
+      print('');
+      print('Happy coding! 🚀');
+    } catch (e) {
+      printError('Failed to create project: $e');
+    }
+  }
+
+  bool _isValidProjectName(String name) {
+    final regex = RegExp(r'^[a-zA-Z][a-zA-Z0-9_]*$');
+    return regex.hasMatch(name);
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/doctor.dart
+++ b/packages/dartango_cli/lib/src/commands/doctor.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+
+class DoctorCommand extends Command {
+  @override
+  String get name => 'doctor';
+
+  @override
+  String get description => 'Check project health and dependencies';
+
+  @override
+  String get help => '''
+Check the health of your Dartango project and development environment.
+
+This command validates:
+- Dart SDK version
+- Project structure
+- Dependencies
+- Configuration files
+- Database connections
+- Common issues
+
+Examples:
+  dartango doctor
+  dartango doctor --verbose
+  dartango doctor --fix
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addFlag('verbose', abbr: 'v', defaultsTo: false,
+        help: 'Show detailed information');
+    parser.addFlag('fix', abbr: 'f', defaultsTo: false,
+        help: 'Attempt to fix common issues');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    final verbose = args['verbose'] as bool;
+    final fix = args['fix'] as bool;
+
+    printInfo('Dartango Doctor - Project Health Check');
+    print('');
+
+    var hasIssues = false;
+    
+    // Check Dart SDK
+    hasIssues = await _checkDartSdk(verbose) || hasIssues;
+    
+    // Check project structure
+    hasIssues = await _checkProjectStructure(verbose, fix) || hasIssues;
+    
+    // Check dependencies
+    hasIssues = await _checkDependencies(verbose, fix) || hasIssues;
+    
+    // Check configuration
+    hasIssues = await _checkConfiguration(verbose, fix) || hasIssues;
+    
+    // Check database
+    hasIssues = await _checkDatabase(verbose) || hasIssues;
+    
+    print('');
+    if (hasIssues) {
+      printWarning('Some issues were found. See details above.');
+      if (!fix) {
+        printInfo('Run with --fix to attempt automatic fixes');
+      }
+    } else {
+      printSuccess('No issues found! Your project looks healthy. 🎉');
+    }
+  }
+
+  Future<bool> _checkDartSdk(bool verbose) async {
+    printInfo('Checking Dart SDK...');
+    
+    try {
+      final result = await Process.run('dart', ['--version']);
+      final version = result.stdout.toString().trim();
+      
+      if (verbose) {
+        print('  $version');
+      }
+      
+      // Check minimum version (3.0.0)
+      final versionMatch = RegExp(r'(\d+)\.(\d+)\.(\d+)').firstMatch(version);
+      if (versionMatch != null) {
+        final major = int.parse(versionMatch.group(1)!);
+        
+        if (major < 3) {
+          printError('  Dart SDK version 3.0.0 or higher is required');
+          return true;
+        }
+      }
+      
+      printSuccess('  Dart SDK version is compatible');
+      return false;
+    } catch (e) {
+      printError('  Dart SDK not found or not in PATH');
+      return true;
+    }
+  }
+
+  Future<bool> _checkProjectStructure(bool verbose, bool fix) async {
+    printInfo('Checking project structure...');
+    
+    var hasIssues = false;
+    
+    final requiredFiles = [
+      'pubspec.yaml',
+      'lib/',
+      'bin/',
+      'test/',
+    ];
+    
+    final optionalFiles = [
+      'README.md',
+      'CHANGELOG.md',
+      'analysis_options.yaml',
+      '.gitignore',
+    ];
+    
+    for (final file in requiredFiles) {
+      if (!await FileSystemEntity.isFile(file) && !await FileSystemEntity.isDirectory(file)) {
+        printError('  Missing required file/directory: $file');
+        hasIssues = true;
+        
+        if (fix) {
+          await _createMissingStructure(file);
+        }
+      } else if (verbose) {
+        printSuccess('  Found: $file');
+      }
+    }
+    
+    for (final file in optionalFiles) {
+      if (await FileSystemEntity.isFile(file)) {
+        if (verbose) printSuccess('  Found: $file');
+      } else if (verbose) {
+        printWarning('  Optional file missing: $file');
+      }
+    }
+    
+    if (!hasIssues) {
+      printSuccess('  Project structure is valid');
+    }
+    
+    return hasIssues;
+  }
+
+  Future<bool> _checkDependencies(bool verbose, bool fix) async {
+    printInfo('Checking dependencies...');
+    
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) {
+      printError('  pubspec.yaml not found');
+      return true;
+    }
+    
+    final content = pubspecFile.readAsStringSync();
+    
+    // Check for Dartango dependency
+    if (!content.contains('dartango')) {
+      printError('  Dartango dependency not found in pubspec.yaml');
+      return true;
+    }
+    
+    // Check if pub get has been run
+    final pubspecLock = File('pubspec.lock');
+    if (!pubspecLock.existsSync()) {
+      printWarning('  pubspec.lock not found - dependencies may not be resolved');
+      if (fix) {
+        printInfo('  Running pub get...');
+        await Process.run('dart', ['pub', 'get']);
+      }
+    }
+    
+    // Check for common dependencies
+    final commonDeps = ['args', 'path', 'shelf'];
+    for (final dep in commonDeps) {
+      if (content.contains(dep)) {
+        if (verbose) printSuccess('  Found dependency: $dep');
+      }
+    }
+    
+    printSuccess('  Dependencies check completed');
+    return false;
+  }
+
+  Future<bool> _checkConfiguration(bool verbose, bool fix) async {
+    printInfo('Checking configuration...');
+    
+    var hasIssues = false;
+    
+    // Check for main entry point
+    final mainFile = File('bin/main.dart');
+    if (!mainFile.existsSync()) {
+      printError('  Main entry point not found: bin/main.dart');
+      hasIssues = true;
+      
+      if (fix) {
+        await _createMainFile();
+      }
+    } else if (verbose) {
+      printSuccess('  Found main entry point: bin/main.dart');
+    }
+    
+    // Check analysis options
+    final analysisOptions = File('analysis_options.yaml');
+    if (!analysisOptions.existsSync()) {
+      if (verbose) printWarning('  analysis_options.yaml not found');
+      
+      if (fix) {
+        await _createAnalysisOptions();
+      }
+    } else if (verbose) {
+      printSuccess('  Found analysis_options.yaml');
+    }
+    
+    if (!hasIssues) {
+      printSuccess('  Configuration is valid');
+    }
+    
+    return hasIssues;
+  }
+
+  Future<bool> _checkDatabase(bool verbose) async {
+    printInfo('Checking database connectivity...');
+    
+    // This is a placeholder - in a real implementation,
+    // you would check actual database connections
+    if (verbose) {
+      printInfo('  Database connectivity check not implemented yet');
+    }
+    
+    printSuccess('  Database check completed');
+    return false;
+  }
+
+  Future<void> _createMissingStructure(String path) async {
+    printInfo('  Creating missing structure: $path');
+    
+    if (path.endsWith('/')) {
+      await Directory(path).create(recursive: true);
+    } else {
+      await File(path).create(recursive: true);
+    }
+  }
+
+  Future<void> _createMainFile() async {
+    printInfo('  Creating bin/main.dart');
+    
+    final mainContent = '''
+import 'package:dartango/dartango.dart';
+
+void main() {
+  final app = DartangoApp();
+  
+  // Configure your app here
+  
+  app.run();
+}
+''';
+    
+    await File('bin/main.dart').writeAsString(mainContent);
+  }
+
+  Future<void> _createAnalysisOptions() async {
+    printInfo('  Creating analysis_options.yaml');
+    
+    final analysisContent = '''
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+  
+linter:
+  rules:
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - avoid_print
+''';
+    
+    await File('analysis_options.yaml').writeAsString(analysisContent);
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/generate.dart
+++ b/packages/dartango_cli/lib/src/commands/generate.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+import 'package:path/path.dart' as path;
+
+import '../generators/model_generator.dart';
+import '../generators/view_generator.dart';
+import '../generators/middleware_generator.dart';
+import '../generators/command_generator.dart';
+
+class GenerateCommand extends Command {
+  @override
+  String get name => 'generate';
+
+  @override
+  String get description => 'Generate code scaffolding';
+
+  @override
+  String get help => '''
+Generate various types of code scaffolding for your Dartango project.
+
+Available generators:
+  model       Generate a model class
+  view        Generate a view class
+  middleware  Generate middleware
+  command     Generate a management command
+
+Examples:
+  dartango generate model User
+  dartango generate view UserView --app=users
+  dartango generate middleware AuthMiddleware
+  dartango generate command backup_database
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('app', abbr: 'a', help: 'App to generate code in');
+    parser.addOption('output', abbr: 'o', help: 'Output directory');
+    parser.addFlag('force', abbr: 'f', defaultsTo: false,
+        help: 'Overwrite existing files');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (args.rest.length < 2) {
+      printError('Generator type and name are required');
+      printInfo('Usage: dartango generate <type> <name>');
+      printInfo('');
+      printInfo('Available types: model, view, middleware, command');
+      return;
+    }
+
+    final generatorType = args.rest[0];
+    final name = args.rest[1];
+    final app = args['app'] as String?;
+    final output = args['output'] as String?;
+    final force = args['force'] as bool;
+
+    if (!_isInDartangoProject()) {
+      printError('This command must be run from within a Dartango project');
+      return;
+    }
+
+    try {
+      switch (generatorType) {
+        case 'model':
+          await _generateModel(name, app, output, force);
+          break;
+        case 'view':
+          await _generateView(name, app, output, force);
+          break;
+        case 'middleware':
+          await _generateMiddleware(name, output, force);
+          break;
+        case 'command':
+          await _generateCommand(name, output, force);
+          break;
+        default:
+          printError('Unknown generator type: $generatorType');
+          printInfo('Available types: model, view, middleware, command');
+      }
+    } catch (e) {
+      printError('Failed to generate $generatorType: $e');
+    }
+  }
+
+  Future<void> _generateModel(String name, String? app, String? output, bool force) async {
+    if (app == null) {
+      printError('App name is required for model generation');
+      printInfo('Use --app=<app_name> to specify the app');
+      return;
+    }
+
+    final appPath = path.join('lib', 'apps', app);
+    if (!Directory(appPath).existsSync()) {
+      printError('App "$app" does not exist');
+      printInfo('Run "dartango startapp $app" to create the app first');
+      return;
+    }
+
+    final outputPath = output ?? path.join(appPath, 'models');
+    final generator = ModelGenerator(
+      name: name,
+      app: app,
+      outputPath: outputPath,
+      force: force,
+    );
+
+    await generator.generate();
+    printSuccess('Model "$name" generated successfully!');
+  }
+
+  Future<void> _generateView(String name, String? app, String? output, bool force) async {
+    if (app == null) {
+      printError('App name is required for view generation');
+      printInfo('Use --app=<app_name> to specify the app');
+      return;
+    }
+
+    final appPath = path.join('lib', 'apps', app);
+    if (!Directory(appPath).existsSync()) {
+      printError('App "$app" does not exist');
+      printInfo('Run "dartango startapp $app" to create the app first');
+      return;
+    }
+
+    final outputPath = output ?? path.join(appPath, 'views');
+    final generator = ViewGenerator(
+      name: name,
+      app: app,
+      outputPath: outputPath,
+      force: force,
+    );
+
+    await generator.generate();
+    printSuccess('View "$name" generated successfully!');
+  }
+
+  Future<void> _generateMiddleware(String name, String? output, bool force) async {
+    final outputPath = output ?? path.join('lib', 'middleware');
+    final generator = MiddlewareGenerator(
+      name: name,
+      outputPath: outputPath,
+      force: force,
+    );
+
+    await generator.generate();
+    printSuccess('Middleware "$name" generated successfully!');
+  }
+
+  Future<void> _generateCommand(String name, String? output, bool force) async {
+    final outputPath = output ?? path.join('lib', 'commands');
+    final generator = CommandGenerator(
+      name: name,
+      outputPath: outputPath,
+      force: force,
+    );
+
+    await generator.generate();
+    printSuccess('Command "$name" generated successfully!');
+  }
+
+  bool _isInDartangoProject() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return false;
+    
+    final content = pubspecFile.readAsStringSync();
+    return content.contains('dartango');
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/serve.dart
+++ b/packages/dartango_cli/lib/src/commands/serve.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+
+class ServeCommand extends Command {
+  @override
+  String get name => 'serve';
+
+  @override
+  String get description => 'Start the development server';
+
+  @override
+  String get help => '''
+Start the Dartango development server.
+
+This command starts a local development server that serves your Dartango application.
+The server includes hot reload capabilities and detailed error reporting.
+
+Examples:
+  dartango serve
+  dartango serve --port=3000
+  dartango serve --host=0.0.0.0 --port=8080
+  dartango serve --no-debug
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('host', abbr: 'h', defaultsTo: 'localhost',
+        help: 'Host to bind the server to');
+    parser.addOption('port', abbr: 'p', defaultsTo: '8000',
+        help: 'Port to bind the server to');
+    parser.addFlag('debug', abbr: 'd', defaultsTo: true,
+        help: 'Enable debug mode');
+    parser.addFlag('hot-reload', defaultsTo: true,
+        help: 'Enable hot reload');
+    parser.addFlag('open', abbr: 'o', defaultsTo: false,
+        help: 'Open the app in the default browser');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (!_isInDartangoProject()) {
+      printError('This command must be run from within a Dartango project');
+      return;
+    }
+
+    final host = args['host'] as String;
+    final portStr = args['port'] as String;
+    final debug = args['debug'] as bool;
+    final hotReload = args['hot-reload'] as bool;
+    final open = args['open'] as bool;
+
+    int port;
+    try {
+      port = int.parse(portStr);
+    } catch (e) {
+      printError('Invalid port number: $portStr');
+      return;
+    }
+
+    if (port < 1 || port > 65535) {
+      printError('Port must be between 1 and 65535');
+      return;
+    }
+
+    printInfo('Starting Dartango development server...');
+    printInfo('Host: $host');
+    printInfo('Port: $port');
+    printInfo('Debug mode: ${debug ? 'enabled' : 'disabled'}');
+    printInfo('Hot reload: ${hotReload ? 'enabled' : 'disabled'}');
+    print('');
+
+    try {
+      final process = await Process.start(
+        'dart',
+        ['run', 'bin/main.dart', '--host=$host', '--port=$port'],
+        mode: ProcessStartMode.inheritStdio,
+      );
+
+      if (open) {
+        await _openBrowser('http://$host:$port');
+      }
+
+      printSuccess('Development server running at http://$host:$port/');
+      printInfo('Press Ctrl+C to stop the server');
+      print('');
+
+      // Wait for the process to complete
+      final exitCode = await process.exitCode;
+      
+      if (exitCode != 0) {
+        printError('Server exited with code $exitCode');
+      }
+    } catch (e) {
+      printError('Failed to start server: $e');
+      printInfo('Make sure you have a bin/main.dart file in your project');
+    }
+  }
+
+  Future<void> _openBrowser(String url) async {
+    try {
+      if (Platform.isWindows) {
+        await Process.run('start', [url], runInShell: true);
+      } else if (Platform.isMacOS) {
+        await Process.run('open', [url]);
+      } else if (Platform.isLinux) {
+        await Process.run('xdg-open', [url]);
+      }
+    } catch (e) {
+      printWarning('Failed to open browser: $e');
+    }
+  }
+
+  bool _isInDartangoProject() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return false;
+    
+    final content = pubspecFile.readAsStringSync();
+    return content.contains('dartango');
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/start_app.dart
+++ b/packages/dartango_cli/lib/src/commands/start_app.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+import 'package:path/path.dart' as path;
+
+import '../generators/app_generator.dart';
+
+class StartAppCommand extends Command {
+  @override
+  String get name => 'startapp';
+
+  @override
+  String get description => 'Create a new app within the project';
+
+  @override
+  String get help => '''
+Create a new app within the current Dartango project.
+
+This command creates a new app directory with the following structure:
+- lib/apps/<app_name>/: App module
+- lib/apps/<app_name>/models/: Data models
+- lib/apps/<app_name>/views/: View controllers
+- lib/apps/<app_name>/urls.dart: URL routing
+- test/apps/<app_name>/: App tests
+
+Examples:
+  dartango startapp blog
+  dartango startapp user_management
+  dartango startapp api --template=api-only
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('template', abbr: 't', defaultsTo: 'default',
+        allowed: ['default', 'api-only', 'minimal'],
+        help: 'Template to use for the app');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (args.rest.isEmpty) {
+      printError('App name is required');
+      printInfo('Usage: dartango startapp <app_name>');
+      return;
+    }
+
+    final appName = args.rest[0];
+    final template = args['template'] as String;
+
+    if (!_isValidAppName(appName)) {
+      printError('Invalid app name: $appName');
+      printInfo('App name must contain only letters, numbers, and underscores');
+      return;
+    }
+
+    if (!_isInDartangoProject()) {
+      printError('This command must be run from within a Dartango project');
+      printInfo('Run "dartango create <project_name>" to create a new project first');
+      return;
+    }
+
+    final appPath = path.join('lib', 'apps', appName);
+    final appDir = Directory(appPath);
+
+    if (await appDir.exists()) {
+      printError('App directory already exists: $appPath');
+      return;
+    }
+
+    printInfo('Creating app: $appName');
+    printInfo('Template: $template');
+
+    try {
+      final generator = AppGenerator(
+        appName: appName,
+        template: template,
+        outputPath: appPath,
+      );
+
+      await generator.generate();
+      
+      printSuccess('App "$appName" created successfully!');
+      print('');
+      print('Next steps:');
+      print('  1. Add your models to lib/apps/$appName/models/');
+      print('  2. Create views in lib/apps/$appName/views/');
+      print('  3. Configure URLs in lib/apps/$appName/urls.dart');
+      print('  4. Include the app in your main urls.dart');
+      print('');
+      print('Happy coding! 🚀');
+    } catch (e) {
+      printError('Failed to create app: $e');
+    }
+  }
+
+  bool _isValidAppName(String name) {
+    final regex = RegExp(r'^[a-zA-Z][a-zA-Z0-9_]*$');
+    return regex.hasMatch(name);
+  }
+
+  bool _isInDartangoProject() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return false;
+    
+    final content = pubspecFile.readAsStringSync();
+    return content.contains('dartango');
+  }
+}

--- a/packages/dartango_cli/lib/src/commands/test.dart
+++ b/packages/dartango_cli/lib/src/commands/test.dart
@@ -1,0 +1,202 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/src/core/management/command.dart';
+
+class TestCommand extends Command {
+  @override
+  String get name => 'test';
+
+  @override
+  String get description => 'Run tests';
+
+  @override
+  String get help => '''
+Run tests for the Dartango project.
+
+This command runs all tests or specific test files/patterns.
+It supports various test runners and reporting options.
+
+Examples:
+  dartango test
+  dartango test --app=users
+  dartango test --file=test/models/user_test.dart
+  dartango test --coverage
+  dartango test --watch
+''';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    parser.addOption('app', abbr: 'a', help: 'Run tests for specific app');
+    parser.addOption('file', abbr: 'f', help: 'Run specific test file');
+    parser.addOption('pattern', abbr: 'p', help: 'Run tests matching pattern');
+    parser.addFlag('coverage', abbr: 'c', defaultsTo: false,
+        help: 'Generate code coverage report');
+    parser.addFlag('watch', abbr: 'w', defaultsTo: false,
+        help: 'Watch for changes and re-run tests');
+    parser.addFlag('verbose', abbr: 'v', defaultsTo: false,
+        help: 'Enable verbose output');
+    parser.addOption('reporter', abbr: 'r', defaultsTo: 'compact',
+        allowed: ['compact', 'expanded', 'json'],
+        help: 'Test reporter format');
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    if (!_isInDartangoProject()) {
+      printError('This command must be run from within a Dartango project');
+      return;
+    }
+
+    final app = args['app'] as String?;
+    final file = args['file'] as String?;
+    final pattern = args['pattern'] as String?;
+    final coverage = args['coverage'] as bool;
+    final watch = args['watch'] as bool;
+    final verbose = args['verbose'] as bool;
+    final reporter = args['reporter'] as String;
+
+    if (!Directory('test').existsSync()) {
+      printError('No test directory found');
+      printInfo('Create a test directory and add some tests first');
+      return;
+    }
+
+    final testArgs = <String>['test'];
+
+    // Add specific test file or pattern
+    if (file != null) {
+      if (!File(file).existsSync()) {
+        printError('Test file not found: $file');
+        return;
+      }
+      testArgs.add(file);
+    } else if (app != null) {
+      final appTestDir = 'test/apps/$app';
+      if (!Directory(appTestDir).existsSync()) {
+        printError('No tests found for app: $app');
+        return;
+      }
+      testArgs.add(appTestDir);
+    } else if (pattern != null) {
+      testArgs.addAll(['--name', pattern]);
+    }
+
+    // Add reporter
+    testArgs.addAll(['--reporter', reporter]);
+
+    // Add coverage
+    if (coverage) {
+      testArgs.add('--coverage=coverage');
+    }
+
+    // Add verbose
+    if (verbose) {
+      testArgs.add('--verbose');
+    }
+
+    printInfo('Running tests...');
+    if (app != null) printInfo('App: $app');
+    if (file != null) printInfo('File: $file');
+    if (pattern != null) printInfo('Pattern: $pattern');
+    if (coverage) printInfo('Coverage: enabled');
+    print('');
+
+    try {
+      if (watch) {
+        await _runTestsWithWatch(testArgs);
+      } else {
+        await _runTests(testArgs, coverage);
+      }
+    } catch (e) {
+      printError('Test execution failed: $e');
+    }
+  }
+
+  Future<void> _runTests(List<String> testArgs, bool coverage) async {
+    final process = await Process.start(
+      'dart',
+      testArgs,
+      mode: ProcessStartMode.inheritStdio,
+    );
+
+    final exitCode = await process.exitCode;
+
+    if (exitCode == 0) {
+      printSuccess('All tests passed!');
+      
+      if (coverage) {
+        print('');
+        printInfo('Generating coverage report...');
+        await _generateCoverageReport();
+      }
+    } else {
+      printError('Some tests failed (exit code: $exitCode)');
+    }
+  }
+
+  Future<void> _runTestsWithWatch(List<String> testArgs) async {
+    printInfo('Running tests in watch mode...');
+    printInfo('Press Ctrl+C to stop watching');
+    print('');
+
+    // Remove any existing watch flags
+    testArgs.removeWhere((arg) => arg.startsWith('--watch'));
+
+    while (true) {
+      final process = await Process.start(
+        'dart',
+        testArgs,
+        mode: ProcessStartMode.inheritStdio,
+      );
+
+      await process.exitCode;
+
+      print('');
+      printInfo('Waiting for file changes...');
+      
+      // Simple file watching - in a real implementation, you'd use a proper file watcher
+      await Future.delayed(const Duration(seconds: 2));
+    }
+  }
+
+  Future<void> _generateCoverageReport() async {
+    try {
+      // Generate HTML coverage report
+      final formatProcess = await Process.start(
+        'dart',
+        ['run', 'coverage:format_coverage', '--lcov', '--in=coverage', '--out=coverage/lcov.info'],
+        mode: ProcessStartMode.normal,
+      );
+
+      await formatProcess.exitCode;
+
+      // Generate HTML report
+      final htmlProcess = await Process.start(
+        'genhtml',
+        ['coverage/lcov.info', '-o', 'coverage/html'],
+        mode: ProcessStartMode.normal,
+      );
+
+      final htmlExitCode = await htmlProcess.exitCode;
+
+      if (htmlExitCode == 0) {
+        printSuccess('Coverage report generated: coverage/html/index.html');
+      } else {
+        printWarning('HTML coverage report generation failed. Install genhtml for HTML reports.');
+        printInfo('Coverage data available at: coverage/lcov.info');
+      }
+    } catch (e) {
+      printWarning('Coverage report generation failed: $e');
+    }
+  }
+
+  bool _isInDartangoProject() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return false;
+    
+    final content = pubspecFile.readAsStringSync();
+    return content.contains('dartango');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/app_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/app_generator.dart
@@ -1,0 +1,431 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class AppGenerator {
+  final String appName;
+  final String template;
+  final String outputPath;
+
+  AppGenerator({
+    required this.appName,
+    required this.template,
+    required this.outputPath,
+  });
+
+  Future<void> generate() async {
+    final appDir = Directory(outputPath);
+    await appDir.create(recursive: true);
+
+    // Generate core app files
+    await _generateModelsFile();
+    await _generateViewsFile();
+    await _generateUrlsFile();
+    await _generateAppsFile();
+    await _generateTestFiles();
+
+    // Generate template-specific files
+    switch (template) {
+      case 'api-only':
+        await _generateApiOnlyFiles();
+        break;
+      case 'minimal':
+        await _generateMinimalFiles();
+        break;
+      case 'default':
+      default:
+        await _generateDefaultFiles();
+        break;
+    }
+  }
+
+  Future<void> _generateModelsFile() async {
+    final modelsDir = Directory(path.join(outputPath, 'models'));
+    await modelsDir.create(recursive: true);
+
+    final modelsContent = '''
+import 'package:dartango/dartango.dart';
+
+// Add your models here
+// Example:
+// class ${_toPascalCase(appName)}Model extends Model {
+//   static const String tableName = '${appName}_model';
+//   
+//   final CharField name = CharField(maxLength: 100);
+//   final TextField description = TextField();
+//   final DateTimeField createdAt = DateTimeField(autoNow: true);
+//   
+//   @override
+//   String toString() => name.value ?? 'Unnamed ${_toPascalCase(appName)}Model';
+// }
+''';
+
+    await File(path.join(modelsDir.path, '${appName}_model.dart')).writeAsString(modelsContent);
+  }
+
+  Future<void> _generateViewsFile() async {
+    final viewsDir = Directory(path.join(outputPath, 'views'));
+    await viewsDir.create(recursive: true);
+
+    final viewsContent = '''
+import 'package:dartango/dartango.dart';
+
+class ${_toPascalCase(appName)}ListView extends ListView {
+  @override
+  String get templateName => '$appName/${appName}_list.html';
+  
+  @override
+  Future<QuerySet> getQuerySet() async {
+    // Return your model queryset here
+    // Example: return ${_toPascalCase(appName)}Model.objects.all();
+    return Future.value(QuerySet([]));
+  }
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(appName)} List',
+      'app_name': '$appName',
+    };
+  }
+}
+
+class ${_toPascalCase(appName)}DetailView extends DetailView {
+  @override
+  String get templateName => '$appName/${appName}_detail.html';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(appName)} Detail',
+      'app_name': '$appName',
+    };
+  }
+}
+
+class ${_toPascalCase(appName)}CreateView extends CreateView {
+  @override
+  String get templateName => '$appName/${appName}_form.html';
+  
+  @override
+  String get successUrl => '/$appName/';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': 'Create ${_toTitleCase(appName)}',
+      'app_name': '$appName',
+    };
+  }
+}
+''';
+
+    await File(path.join(viewsDir.path, '${appName}_views.dart')).writeAsString(viewsContent);
+  }
+
+  Future<void> _generateUrlsFile() async {
+    final urlsContent = '''
+import 'package:dartango/dartango.dart';
+import 'views/${appName}_views.dart';
+
+final urlPatterns = [
+  path('', ${_toPascalCase(appName)}ListView.asView(), name: '${appName}_list'),
+  path('<int:id>/', ${_toPascalCase(appName)}DetailView.asView(), name: '${appName}_detail'),
+  path('create/', ${_toPascalCase(appName)}CreateView.asView(), name: '${appName}_create'),
+];
+''';
+
+    await File(path.join(outputPath, 'urls.dart')).writeAsString(urlsContent);
+  }
+
+  Future<void> _generateAppsFile() async {
+    final appsContent = '''
+import 'package:dartango/dartango.dart';
+
+class ${_toPascalCase(appName)}Config extends AppConfig {
+  @override
+  String get name => '$appName';
+  
+  @override
+  String get label => '${_toTitleCase(appName)}';
+  
+  @override
+  String get verbose_name => '${_toTitleCase(appName)} Application';
+  
+  @override
+  void ready() {
+    // Perform any app initialization here
+    super.ready();
+  }
+}
+''';
+
+    await File(path.join(outputPath, 'apps.dart')).writeAsString(appsContent);
+  }
+
+  Future<void> _generateTestFiles() async {
+    final testDir = Directory(path.join(outputPath, 'test'));
+    await testDir.create(recursive: true);
+
+    final testContent = '''
+import 'package:test/test.dart';
+import 'package:dartango/dartango.dart';
+import '../views/${appName}_views.dart';
+
+void main() {
+  group('${_toPascalCase(appName)} Views', () {
+    late TestClient client;
+
+    setUp(() {
+      client = TestClient();
+    });
+
+    test('${appName} list view should return 200', () async {
+      final response = await client.get('/$appName/');
+      expect(response.statusCode, equals(200));
+    });
+
+    test('${appName} detail view should return 200', () async {
+      final response = await client.get('/$appName/1/');
+      expect(response.statusCode, equals(200));
+    });
+
+    test('${appName} create view should return 200', () async {
+      final response = await client.get('/$appName/create/');
+      expect(response.statusCode, equals(200));
+    });
+  });
+}
+''';
+
+    await File(path.join(testDir.path, 'test_${appName}_views.dart')).writeAsString(testContent);
+  }
+
+  Future<void> _generateDefaultFiles() async {
+    // Generate templates for default template
+    final templatesDir = Directory(path.join(outputPath, 'templates', appName));
+    await templatesDir.create(recursive: true);
+
+    final listTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>{{ title }}</h1>
+    
+    <div class="actions">
+        <a href="{% url '${appName}_create' %}" class="btn btn-primary">
+            Create New ${_toTitleCase(appName)}
+        </a>
+    </div>
+    
+    <div class="list-container">
+        {% for item in object_list %}
+        <div class="item">
+            <h3>
+                <a href="{% url '${appName}_detail' item.id %}">
+                    {{ item.name }}
+                </a>
+            </h3>
+            <p>{{ item.description }}</p>
+            <small>Created: {{ item.created_at }}</small>
+        </div>
+        {% empty %}
+        <p>No ${appName} items found.</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${appName}_list.html')).writeAsString(listTemplate);
+
+    final detailTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>{{ object.name }}</h1>
+    
+    <div class="actions">
+        <a href="{% url '${appName}_list' %}" class="btn btn-secondary">
+            Back to List
+        </a>
+        <a href="{% url '${appName}_edit' object.id %}" class="btn btn-primary">
+            Edit
+        </a>
+    </div>
+    
+    <div class="detail-container">
+        <p><strong>Description:</strong> {{ object.description }}</p>
+        <p><strong>Created:</strong> {{ object.created_at }}</p>
+        <p><strong>Modified:</strong> {{ object.modified_at }}</p>
+    </div>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${appName}_detail.html')).writeAsString(detailTemplate);
+
+    final formTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>{{ title }}</h1>
+    
+    <form method="post">
+        {% csrf_token %}
+        
+        <div class="form-group">
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" value="{{ form.name.value }}" required>
+            {% if form.name.errors %}
+                <div class="error">{{ form.name.errors }}</div>
+            {% endif %}
+        </div>
+        
+        <div class="form-group">
+            <label for="description">Description:</label>
+            <textarea id="description" name="description">{{ form.description.value }}</textarea>
+            {% if form.description.errors %}
+                <div class="error">{{ form.description.errors }}</div>
+            {% endif %}
+        </div>
+        
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a href="{% url '${appName}_list' %}" class="btn btn-secondary">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${appName}_form.html')).writeAsString(formTemplate);
+  }
+
+  Future<void> _generateApiOnlyFiles() async {
+    // Override views for API-only template
+    final viewsDir = Directory(path.join(outputPath, 'views'));
+    
+    final apiViewsContent = '''
+import 'package:dartango/dartango.dart';
+
+class ${_toPascalCase(appName)}ApiView extends View {
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    // List all items
+    final items = []; // Replace with actual queryset
+    
+    return JsonResponse({
+      'results': items,
+      'count': items.length,
+    });
+  }
+  
+  @override
+  Future<HttpResponse> post(HttpRequest request) async {
+    // Create new item
+    final data = await request.json();
+    
+    // Validate and save data here
+    
+    return JsonResponse({
+      'id': 1,
+      'message': '${_toTitleCase(appName)} created successfully',
+    }, statusCode: 201);
+  }
+}
+
+class ${_toPascalCase(appName)}DetailApiView extends View {
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    final id = request.pathParams['id'];
+    
+    // Fetch item by ID
+    final item = {}; // Replace with actual item fetch
+    
+    if (item.isEmpty) {
+      return JsonResponse({
+        'error': '${_toTitleCase(appName)} not found',
+      }, statusCode: 404);
+    }
+    
+    return JsonResponse(item);
+  }
+  
+  @override
+  Future<HttpResponse> put(HttpRequest request) async {
+    final id = request.pathParams['id'];
+    final data = await request.json();
+    
+    // Update item
+    
+    return JsonResponse({
+      'id': id,
+      'message': '${_toTitleCase(appName)} updated successfully',
+    });
+  }
+  
+  @override
+  Future<HttpResponse> delete(HttpRequest request) async {
+    final id = request.pathParams['id'];
+    
+    // Delete item
+    
+    return JsonResponse({
+      'message': '${_toTitleCase(appName)} deleted successfully',
+    });
+  }
+}
+''';
+
+    await File(path.join(viewsDir.path, '${appName}_api_views.dart')).writeAsString(apiViewsContent);
+
+    // Override URLs for API
+    final apiUrlsContent = '''
+import 'package:dartango/dartango.dart';
+import 'views/${appName}_api_views.dart';
+
+final urlPatterns = [
+  path('', ${_toPascalCase(appName)}ApiView.asView(), name: '${appName}_api'),
+  path('<int:id>/', ${_toPascalCase(appName)}DetailApiView.asView(), name: '${appName}_detail_api'),
+];
+''';
+
+    await File(path.join(outputPath, 'urls.dart')).writeAsString(apiUrlsContent);
+  }
+
+  Future<void> _generateMinimalFiles() async {
+    // Generate minimal template files
+    final templatesDir = Directory(path.join(outputPath, 'templates', appName));
+    await templatesDir.create(recursive: true);
+
+    final minimalTemplate = '''
+<h1>${_toTitleCase(appName)}</h1>
+<p>Welcome to the $appName app!</p>
+''';
+
+    await File(path.join(templatesDir.path, '${appName}_simple.html')).writeAsString(minimalTemplate);
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+
+  String _toTitleCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join(' ');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/command_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/command_generator.dart
@@ -1,0 +1,418 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class CommandGenerator {
+  final String name;
+  final String outputPath;
+  final bool force;
+
+  CommandGenerator({
+    required this.name,
+    required this.outputPath,
+    this.force = false,
+  });
+
+  Future<void> generate() async {
+    final commandsDir = Directory(outputPath);
+    await commandsDir.create(recursive: true);
+
+    final commandFileName = '${_toSnakeCase(name)}.dart';
+    final commandFile = File(path.join(commandsDir.path, commandFileName));
+
+    if (await commandFile.exists() && !force) {
+      throw Exception('Command file already exists: ${commandFile.path}');
+    }
+
+    final commandContent = _generateCommandContent();
+    await commandFile.writeAsString(commandContent);
+  }
+
+  String _generateCommandContent() {
+    final className = _toPascalCase(name);
+    final commandName = _toSnakeCase(name);
+
+    return '''
+import 'dart:async';
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:dartango/dartango.dart';
+
+/// ${_toTitleCase(name)} management command
+/// 
+/// This command handles ${_toTitleCase(name).toLowerCase()} operations.
+/// Customize the execute method to implement your specific functionality.
+class ${className}Command extends Command {
+  @override
+  String get name => '$commandName';
+
+  @override
+  String get description => '${_toTitleCase(name)} management command';
+
+  @override
+  String get help => 'Help for ${_toTitleCase(name)} command';
+
+  @override
+  ArgParser get argParser {
+    final parser = ArgParser();
+    
+    // Common options
+    parser.addFlag('verbose', abbr: 'v', defaultsTo: false,
+        help: 'Enable verbose output');
+    parser.addFlag('dry-run', abbr: 'd', defaultsTo: false,
+        help: 'Show what would be done without actually doing it');
+    parser.addFlag('force', abbr: 'f', defaultsTo: false,
+        help: 'Force execution even if there are warnings');
+    
+    // Custom options for this command
+    parser.addOption('option1', abbr: 'o', defaultsTo: 'default_value',
+        help: 'Custom option 1 for ${_toTitleCase(name)}');
+    parser.addOption('option2', help: 'Custom option 2 for ${_toTitleCase(name)}');
+    parser.addFlag('enable-feature', defaultsTo: false,
+        help: 'Enable a specific feature');
+    
+    return parser;
+  }
+
+  @override
+  Future<void> execute(ArgResults args) async {
+    final verbose = args['verbose'] as bool;
+    final dryRun = args['dry-run'] as bool;
+    final force = args['force'] as bool;
+    final option1 = args['option1'] as String;
+    final option2 = args['option2'] as String?;
+    final enableFeature = args['enable-feature'] as bool;
+
+    if (verbose) {
+      printInfo('Starting ${_toTitleCase(name)} command execution');
+      printInfo('Options:');
+      printInfo('  Verbose: \$verbose');
+      printInfo('  Dry run: \$dryRun');
+      printInfo('  Force: \$force');
+      printInfo('  Option 1: \$option1');
+      printInfo('  Option 2: \${option2 ?? 'not set'}');
+      printInfo('  Enable feature: \$enableFeature');
+    }
+
+    try {
+      // Validate prerequisites
+      if (!await _validatePrerequisites(verbose)) {
+        printError('Prerequisites validation failed');
+        return;
+      }
+
+      // Check for warnings
+      final warnings = await _checkWarnings();
+      if (warnings.isNotEmpty && !force) {
+        printWarning('Warnings found:');
+        for (final warning in warnings) {
+          printWarning('  - \$warning');
+        }
+        printInfo('Use --force to proceed anyway');
+        return;
+      }
+
+      // Execute the main logic
+      await _executeMainLogic(args, verbose, dryRun);
+
+      // Cleanup if needed
+      await _cleanup(verbose);
+
+      printSuccess('${_toTitleCase(name)} command completed successfully!');
+    } catch (e) {
+      printError('${_toTitleCase(name)} command failed: \$e');
+      if (verbose) {
+        printError('Stack trace: \${StackTrace.current}');
+      }
+    }
+  }
+
+  /// Validate prerequisites before running the command
+  Future<bool> _validatePrerequisites(bool verbose) async {
+    if (verbose) {
+      printInfo('Validating prerequisites...');
+    }
+
+    // Example validations
+    final validations = [
+      _checkDatabaseConnection(),
+      _checkRequiredFiles(),
+      _checkPermissions(),
+    ];
+
+    final results = await Future.wait(validations);
+    final allValid = results.every((result) => result);
+
+    if (verbose) {
+      printInfo('Prerequisites validation: \${allValid ? 'passed' : 'failed'}');
+    }
+
+    return allValid;
+  }
+
+  /// Check for warnings that might affect execution
+  Future<List<String>> _checkWarnings() async {
+    final warnings = <String>[];
+
+    // Example warning checks
+    if (!await _isDatabaseEmpty()) {
+      warnings.add('Database is not empty, existing data might be affected');
+    }
+
+    if (!await _hasBackup()) {
+      warnings.add('No recent backup found, consider creating one first');
+    }
+
+    return warnings;
+  }
+
+  /// Execute the main command logic
+  Future<void> _executeMainLogic(ArgResults args, bool verbose, bool dryRun) async {
+    if (verbose) {
+      printInfo('Executing main logic...');
+    }
+
+    // Step 1: Preparation
+    await _prepareExecution(verbose, dryRun);
+
+    // Step 2: Process data
+    await _processData(args, verbose, dryRun);
+
+    // Step 3: Apply changes
+    await _applyChanges(verbose, dryRun);
+
+    // Step 4: Verify results
+    await _verifyResults(verbose);
+  }
+
+  /// Prepare for execution
+  Future<void> _prepareExecution(bool verbose, bool dryRun) async {
+    if (verbose) {
+      printInfo('Preparing execution...');
+    }
+
+    if (dryRun) {
+      printInfo('[DRY RUN] Would prepare execution environment');
+      return;
+    }
+
+    // Implement your preparation logic here
+    // Example: Create temporary directories, load configuration, etc.
+    await _createTempDirectories();
+    await _loadConfiguration();
+  }
+
+  /// Process data according to command logic
+  Future<void> _processData(ArgResults args, bool verbose, bool dryRun) async {
+    if (verbose) {
+      printInfo('Processing data...');
+    }
+
+    final option1 = args['option1'] as String;
+    final option2 = args['option2'] as String?;
+    final enableFeature = args['enable-feature'] as bool;
+
+    if (dryRun) {
+      printInfo('[DRY RUN] Would process data with options:');
+      printInfo('  Option 1: \$option1');
+      printInfo('  Option 2: \${option2 ?? 'not set'}');
+      printInfo('  Enable feature: \$enableFeature');
+      return;
+    }
+
+    // Implement your data processing logic here
+    // Example: Read files, query database, transform data, etc.
+    await _readInputData();
+    await _transformData(option1, option2, enableFeature);
+  }
+
+  /// Apply changes based on processed data
+  Future<void> _applyChanges(bool verbose, bool dryRun) async {
+    if (verbose) {
+      printInfo('Applying changes...');
+    }
+
+    if (dryRun) {
+      printInfo('[DRY RUN] Would apply changes to the system');
+      return;
+    }
+
+    // Implement your change application logic here
+    // Example: Update database, write files, send notifications, etc.
+    await _updateDatabase();
+    await _writeOutputFiles();
+    await _sendNotifications();
+  }
+
+  /// Verify that the results are correct
+  Future<void> _verifyResults(bool verbose) async {
+    if (verbose) {
+      printInfo('Verifying results...');
+    }
+
+    // Implement your verification logic here
+    // Example: Check database integrity, validate files, etc.
+    final isValid = await _validateResults();
+    
+    if (isValid) {
+      if (verbose) {
+        printSuccess('Results verification passed');
+      }
+    } else {
+      throw Exception('Results verification failed');
+    }
+  }
+
+  /// Cleanup resources and temporary files
+  Future<void> _cleanup(bool verbose) async {
+    if (verbose) {
+      printInfo('Cleaning up...');
+    }
+
+    // Implement your cleanup logic here
+    await _removeTempDirectories();
+    await _closeConnections();
+  }
+
+  // Helper methods for validation
+  Future<bool> _checkDatabaseConnection() async {
+    // Implement database connection check
+    return true; // Placeholder
+  }
+
+  Future<bool> _checkRequiredFiles() async {
+    // Implement required files check
+    return true; // Placeholder
+  }
+
+  Future<bool> _checkPermissions() async {
+    // Implement permissions check
+    return true; // Placeholder
+  }
+
+  Future<bool> _isDatabaseEmpty() async {
+    // Implement database empty check
+    return false; // Placeholder
+  }
+
+  Future<bool> _hasBackup() async {
+    // Implement backup check
+    return true; // Placeholder
+  }
+
+  // Helper methods for execution
+  Future<void> _createTempDirectories() async {
+    // Implement temp directory creation
+    final tempDir = Directory('.tmp/$commandName');
+    if (!await tempDir.exists()) {
+      await tempDir.create(recursive: true);
+    }
+  }
+
+  Future<void> _loadConfiguration() async {
+    // Implement configuration loading
+  }
+
+  Future<void> _readInputData() async {
+    // Implement input data reading
+  }
+
+  Future<void> _transformData(String option1, String? option2, bool enableFeature) async {
+    // Implement data transformation logic
+  }
+
+  Future<void> _updateDatabase() async {
+    // Implement database update logic
+  }
+
+  Future<void> _writeOutputFiles() async {
+    // Implement output file writing
+  }
+
+  Future<void> _sendNotifications() async {
+    // Implement notification sending
+  }
+
+  Future<bool> _validateResults() async {
+    // Implement results validation
+    return true; // Placeholder
+  }
+
+  Future<void> _removeTempDirectories() async {
+    // Implement temp directory removal
+    final tempDir = Directory('.tmp/$commandName');
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  }
+
+  Future<void> _closeConnections() async {
+    // Implement connection closing
+  }
+}
+
+// Utility class for command-specific operations
+class ${className}Utils {
+  static Future<Map<String, dynamic>> readConfig(String configPath) async {
+    // Implement config reading
+    return {};
+  }
+
+  static Future<void> writeConfig(String configPath, Map<String, dynamic> config) async {
+    // Implement config writing
+  }
+
+  static String formatOutput(dynamic data) {
+    // Implement output formatting
+    return data.toString();
+  }
+
+  static bool validateInput(String input) {
+    // Implement input validation
+    return input.isNotEmpty;
+  }
+}
+
+// Custom exception for command-specific errors
+class ${className}Exception implements Exception {
+  final String message;
+  final int? exitCode;
+
+  const ${className}Exception(this.message, [this.exitCode]);
+
+  @override
+  String toString() => message;
+}
+
+// Usage example in comments:
+/*
+// Register the command in your command manager:
+final commandManager = CommandManager();
+commandManager.register(${className}Command());
+
+// Run the command:
+await commandManager.run(['$commandName', '--verbose', '--option1=custom_value']);
+*/
+''';
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+
+  String _toSnakeCase(String input) {
+    return input
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => '_${match.group(1)!.toLowerCase()}')
+        .replaceFirst(RegExp(r'^_'), '')
+        .toLowerCase();
+  }
+
+  String _toTitleCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join(' ');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/middleware_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/middleware_generator.dart
@@ -1,0 +1,328 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class MiddlewareGenerator {
+  final String name;
+  final String outputPath;
+  final bool force;
+
+  MiddlewareGenerator({
+    required this.name,
+    required this.outputPath,
+    this.force = false,
+  });
+
+  Future<void> generate() async {
+    final middlewareDir = Directory(outputPath);
+    await middlewareDir.create(recursive: true);
+
+    final middlewareFileName = '${_toSnakeCase(name)}.dart';
+    final middlewareFile = File(path.join(middlewareDir.path, middlewareFileName));
+
+    if (await middlewareFile.exists() && !force) {
+      throw Exception('Middleware file already exists: ${middlewareFile.path}');
+    }
+
+    final middlewareContent = _generateMiddlewareContent();
+    await middlewareFile.writeAsString(middlewareContent);
+  }
+
+  String _generateMiddlewareContent() {
+    final className = _toPascalCase(name);
+
+    return '''
+import 'dart:async';
+import 'package:dartango/dartango.dart';
+
+/// ${_toTitleCase(name)} middleware
+/// 
+/// This middleware handles ${_toTitleCase(name).toLowerCase()} functionality.
+/// Customize the process_request and process_response methods as needed.
+class $className extends Middleware {
+  @override
+  Future<HttpResponse?> processRequest(HttpRequest request) async {
+    // Process the incoming request
+    // Return null to continue processing, or an HttpResponse to short-circuit
+    
+    // Example: Log the request
+    print('[$className] Processing request: \${request.method} \${request.path}');
+    
+    // Example: Add custom headers
+    request.meta['${_toSnakeCase(name)}_processed'] = true;
+    
+    // Example: Authentication check
+    if (_requiresAuthentication(request)) {
+      final isAuthenticated = await _checkAuthentication(request);
+      if (!isAuthenticated) {
+        return HttpResponse.unauthorized('Authentication required');
+      }
+    }
+    
+    // Example: Rate limiting
+    if (_shouldApplyRateLimit(request)) {
+      final isAllowed = await _checkRateLimit(request);
+      if (!isAllowed) {
+        return HttpResponse.tooManyRequests('Rate limit exceeded');
+      }
+    }
+    
+    // Continue processing
+    return null;
+  }
+
+  @override
+  Future<HttpResponse> processResponse(HttpRequest request, HttpResponse response) async {
+    // Process the response before it's sent to the client
+    
+    // Example: Add custom headers
+    response.headers['X-${_toPascalCase(name)}-Processed'] = 'true';
+    response.headers['X-Processing-Time'] = DateTime.now().toIso8601String();
+    
+    // Example: Log the response
+    print('[$className] Response: \${response.statusCode} for \${request.path}');
+    
+    // Example: Modify response content
+    if (_shouldModifyResponse(request, response)) {
+      return await _modifyResponse(request, response);
+    }
+    
+    return response;
+  }
+
+  @override
+  Future<HttpResponse?> processException(HttpRequest request, Exception exception) async {
+    // Handle exceptions that occur during request processing
+    
+    // Log the exception
+    print('[$className] Exception: \$exception for \${request.path}');
+    
+    // Example: Custom error handling
+    if (exception is ValidationException) {
+      return JsonResponse({
+        'error': 'Validation failed',
+        'details': exception.errors,
+      }, statusCode: 400);
+    }
+    
+    if (exception is AuthenticationException) {
+      return JsonResponse({
+        'error': 'Authentication failed',
+        'message': exception.message,
+      }, statusCode: 401);
+    }
+    
+    // Return null to use default exception handling
+    return null;
+  }
+
+  // Helper methods
+  
+  bool _requiresAuthentication(HttpRequest request) {
+    // Define which paths require authentication
+    final protectedPaths = ['/admin/', '/api/private/'];
+    return protectedPaths.any((path) => request.path.startsWith(path));
+  }
+  
+  Future<bool> _checkAuthentication(HttpRequest request) async {
+    // Implement your authentication logic here
+    final authHeader = request.headers['authorization'];
+    if (authHeader == null) return false;
+    
+    // Example: Bearer token validation
+    if (authHeader.startsWith('Bearer ')) {
+      final token = authHeader.substring(7);
+      return await _validateToken(token);
+    }
+    
+    return false;
+  }
+  
+  Future<bool> _validateToken(String token) async {
+    // Implement token validation logic
+    // This is a placeholder implementation
+    return token.isNotEmpty && token.length > 10;
+  }
+  
+  bool _shouldApplyRateLimit(HttpRequest request) {
+    // Define which paths should have rate limiting
+    final rateLimitedPaths = ['/api/'];
+    return rateLimitedPaths.any((path) => request.path.startsWith(path));
+  }
+  
+  Future<bool> _checkRateLimit(HttpRequest request) async {
+    // Implement rate limiting logic
+    // This is a placeholder implementation
+    final clientIp = request.remoteAddr;
+    
+    // Example: Simple in-memory rate limiting
+    final key = '${_toSnakeCase(name)}_rate_limit_\$clientIp';
+    final now = DateTime.now();
+    
+    // In a real implementation, you'd use a proper cache/database
+    // For now, we'll just return true (allow request)
+    return true;
+  }
+  
+  bool _shouldModifyResponse(HttpRequest request, HttpResponse response) {
+    // Define conditions for response modification
+    return response.statusCode == 200 && 
+           request.path.startsWith('/api/') &&
+           response.headers['content-type']?.startsWith('application/json') == true;
+  }
+  
+  Future<HttpResponse> _modifyResponse(HttpRequest request, HttpResponse response) async {
+    // Modify the response as needed
+    if (response is JsonResponse) {
+      // Add metadata to JSON responses
+      final originalData = response.data;
+      final modifiedData = {
+        'data': originalData,
+        'meta': {
+          'processed_by': '$className',
+          'timestamp': DateTime.now().toIso8601String(),
+          'version': '1.0',
+        },
+      };
+      
+      return JsonResponse(modifiedData, statusCode: response.statusCode);
+    }
+    
+    return response;
+  }
+}
+
+// Configuration class for the middleware
+class ${className}Config {
+  final bool enableLogging;
+  final bool enableAuthentication;
+  final bool enableRateLimit;
+  final Duration rateLimitWindow;
+  final int maxRequestsPerWindow;
+  final List<String> exemptPaths;
+  
+  const ${className}Config({
+    this.enableLogging = true,
+    this.enableAuthentication = true,
+    this.enableRateLimit = false,
+    this.rateLimitWindow = const Duration(minutes: 1),
+    this.maxRequestsPerWindow = 60,
+    this.exemptPaths = const ['/health', '/status'],
+  });
+}
+
+// Configurable middleware version
+class Configurable$className extends $className {
+  final ${className}Config config;
+  
+  Configurable$className({${className}Config? config})
+      : config = config ?? const ${className}Config();
+  
+  @override
+  Future<HttpResponse?> processRequest(HttpRequest request) async {
+    // Skip processing for exempt paths
+    if (config.exemptPaths.any((path) => request.path.startsWith(path))) {
+      return null;
+    }
+    
+    if (config.enableLogging) {
+      print('[$className] Processing request: \${request.method} \${request.path}');
+    }
+    
+    // Apply authentication if enabled
+    if (config.enableAuthentication && _requiresAuthentication(request)) {
+      final isAuthenticated = await _checkAuthentication(request);
+      if (!isAuthenticated) {
+        return HttpResponse.unauthorized('Authentication required');
+      }
+    }
+    
+    // Apply rate limiting if enabled
+    if (config.enableRateLimit && _shouldApplyRateLimit(request)) {
+      final isAllowed = await _checkRateLimit(request);
+      if (!isAllowed) {
+        return HttpResponse.tooManyRequests('Rate limit exceeded');
+      }
+    }
+    
+    return null;
+  }
+  
+  @override
+  Future<HttpResponse> processResponse(HttpRequest request, HttpResponse response) async {
+    if (config.enableLogging) {
+      print('[$className] Response: \${response.statusCode} for \${request.path}');
+    }
+    
+    return super.processResponse(request, response);
+  }
+}
+
+// Extension for easy registration
+extension ${className}Extension on List<Middleware> {
+  void add$className({${className}Config? config}) {
+    add(Configurable$className(config: config));
+  }
+}
+
+// Custom exceptions
+class ${className}Exception implements Exception {
+  final String message;
+  final int statusCode;
+  
+  const ${className}Exception(this.message, [this.statusCode = 500]);
+  
+  @override
+  String toString() => message;
+}
+
+class ValidationException extends ${className}Exception {
+  final Map<String, List<String>> errors;
+  
+  const ValidationException(this.errors) : super('Validation failed', 400);
+}
+
+class AuthenticationException extends ${className}Exception {
+  const AuthenticationException(String message) : super(message, 401);
+}
+
+// Usage example in comments:
+/*
+// In your main application file:
+final app = DartangoApp();
+app.middleware.add$className(
+  config: ${className}Config(
+    enableLogging: true,
+    enableAuthentication: true,
+    enableRateLimit: true,
+    maxRequestsPerWindow: 100,
+    exemptPaths: ['/health', '/status', '/metrics'],
+  ),
+);
+
+// Or use the basic version:
+app.middleware.add($className());
+*/
+''';
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+
+  String _toSnakeCase(String input) {
+    return input
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => '_${match.group(1)!.toLowerCase()}')
+        .replaceFirst(RegExp(r'^_'), '')
+        .toLowerCase();
+  }
+
+  String _toTitleCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join(' ');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/model_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/model_generator.dart
@@ -1,0 +1,239 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class ModelGenerator {
+  final String name;
+  final String app;
+  final String outputPath;
+  final bool force;
+
+  ModelGenerator({
+    required this.name,
+    required this.app,
+    required this.outputPath,
+    this.force = false,
+  });
+
+  Future<void> generate() async {
+    final modelsDir = Directory(outputPath);
+    await modelsDir.create(recursive: true);
+
+    final modelFileName = '${_toSnakeCase(name)}.dart';
+    final modelFile = File(path.join(modelsDir.path, modelFileName));
+
+    if (await modelFile.exists() && !force) {
+      throw Exception('Model file already exists: ${modelFile.path}');
+    }
+
+    final modelContent = _generateModelContent();
+    await modelFile.writeAsString(modelContent);
+
+    // Generate migration file
+    await _generateMigration();
+  }
+
+  String _generateModelContent() {
+    final className = _toPascalCase(name);
+    final tableName = '${app}_${_toSnakeCase(name)}';
+
+    return '''
+import 'package:dartango/dartango.dart';
+
+class $className extends Model {
+  static const String tableName = '$tableName';
+  
+  // Primary key (auto-generated)
+  final AutoField id = AutoField(primaryKey: true);
+  
+  // Common fields - customize as needed
+  final CharField name = CharField(
+    maxLength: 100,
+    verbose_name: 'Name',
+    help_text: 'Enter the name',
+  );
+  
+  final TextField description = TextField(
+    verbose_name: 'Description',
+    help_text: 'Enter a description',
+    blank: true,
+  );
+  
+  final BooleanField isActive = BooleanField(
+    default: true,
+    verbose_name: 'Active',
+    help_text: 'Whether this item is active',
+  );
+  
+  final DateTimeField createdAt = DateTimeField(
+    autoNow: true,
+    verbose_name: 'Created At',
+  );
+  
+  final DateTimeField updatedAt = DateTimeField(
+    autoNowAdd: true,
+    verbose_name: 'Updated At',
+  );
+  
+  @override
+  String toString() {
+    return name.value ?? 'Unnamed $className';
+  }
+  
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id.value,
+      'name': name.value,
+      'description': description.value,
+      'is_active': isActive.value,
+      'created_at': createdAt.value?.toIso8601String(),
+      'updated_at': updatedAt.value?.toIso8601String(),
+    };
+  }
+  
+  @override
+  void fromJson(Map<String, dynamic> json) {
+    id.value = json['id'];
+    name.value = json['name'];
+    description.value = json['description'];
+    isActive.value = json['is_active'] ?? true;
+    createdAt.value = json['created_at'] != null 
+        ? DateTime.parse(json['created_at']) 
+        : null;
+    updatedAt.value = json['updated_at'] != null 
+        ? DateTime.parse(json['updated_at']) 
+        : null;
+  }
+  
+  // Custom methods
+  Future<void> activate() async {
+    isActive.value = true;
+    await save();
+  }
+  
+  Future<void> deactivate() async {
+    isActive.value = false;
+    await save();
+  }
+  
+  // Custom querysets
+  static Future<List<$className>> getActive() async {
+    return await objects.filter({'is_active': true}).all();
+  }
+  
+  static Future<List<$className>> getByName(String namePattern) async {
+    return await objects.filter({'name__icontains': namePattern}).all();
+  }
+  
+  // Meta class for additional configuration
+  class Meta {
+    static const String tableName = '$tableName';
+    static const String verbose_name = '${_toTitleCase(name)}';
+    static const String verbose_name_plural = '${_toTitleCase(name)}s';
+    static const List<String> ordering = ['-created_at'];
+    static const Map<String, dynamic> indexes = {
+      'name_idx': ['name'],
+      'active_idx': ['is_active'],
+    };
+  }
+}
+
+// Custom manager for additional query methods
+class ${className}Manager extends Manager<$className> {
+  ${className}Manager() : super($className);
+  
+  Future<List<$className>> getActiveByName(String name) async {
+    return await filter({
+      'is_active': true,
+      'name__icontains': name,
+    }).all();
+  }
+  
+  Future<$className?> getByNameExact(String name) async {
+    try {
+      return await get({'name': name});
+    } catch (e) {
+      return null;
+    }
+  }
+  
+  Future<int> getActiveCount() async {
+    return await filter({'is_active': true}).count();
+  }
+}
+
+// Add custom manager to model
+extension ${className}Objects on $className {
+  static ${className}Manager get objects => ${className}Manager();
+}
+''';
+  }
+
+  Future<void> _generateMigration() async {
+    final migrationsDir = Directory(path.join(outputPath, '..', 'migrations'));
+    await migrationsDir.create(recursive: true);
+
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final migrationFileName = '${timestamp}_create_${_toSnakeCase(name)}.dart';
+    final migrationFile = File(path.join(migrationsDir.path, migrationFileName));
+
+    final migrationContent = _generateMigrationContent();
+    await migrationFile.writeAsString(migrationContent);
+  }
+
+  String _generateMigrationContent() {
+    final className = _toPascalCase(name);
+    final tableName = '${app}_${_toSnakeCase(name)}';
+
+    return '''
+import 'package:dartango/dartango.dart';
+
+class Create$className extends Migration {
+  @override
+  List<Operation> get operations => [
+    CreateTable(
+      name: '$tableName',
+      fields: [
+        Field('id', FieldType.autoField, primaryKey: true),
+        Field('name', FieldType.charField, maxLength: 100, null: false),
+        Field('description', FieldType.textField, null: true),
+        Field('is_active', FieldType.booleanField, default: true),
+        Field('created_at', FieldType.dateTimeField, autoNow: true),
+        Field('updated_at', FieldType.dateTimeField, autoNowAdd: true),
+      ],
+      indexes: [
+        Index(fields: ['name'], name: '${tableName}_name_idx'),
+        Index(fields: ['is_active'], name: '${tableName}_active_idx'),
+      ],
+    ),
+  ];
+  
+  @override
+  List<Operation> get reverseOperations => [
+    DropTable(name: '$tableName'),
+  ];
+}
+''';
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+
+  String _toSnakeCase(String input) {
+    return input
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => '_${match.group(1)!.toLowerCase()}')
+        .replaceFirst(RegExp(r'^_'), '')
+        .toLowerCase();
+  }
+
+  String _toTitleCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join(' ');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/project_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/project_generator.dart
@@ -1,0 +1,503 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class ProjectGenerator {
+  final String projectName;
+  final String template;
+  final String outputPath;
+
+  ProjectGenerator({
+    required this.projectName,
+    required this.template,
+    required this.outputPath,
+  });
+
+  Future<void> generate() async {
+    final projectDir = Directory(outputPath);
+    await projectDir.create(recursive: true);
+
+    // Generate core project files
+    await _generatePubspec();
+    await _generateMainFile();
+    await _generateLibFiles();
+    await _generateTestFiles();
+    await _generateConfigFiles();
+    await _generateDocumentation();
+    await _generateGitIgnore();
+
+    // Generate template-specific files
+    switch (template) {
+      case 'minimal':
+        await _generateMinimalTemplate();
+        break;
+      case 'api-only':
+        await _generateApiOnlyTemplate();
+        break;
+      case 'default':
+      default:
+        await _generateDefaultTemplate();
+        break;
+    }
+  }
+
+  Future<void> _generatePubspec() async {
+    final pubspecContent = '''
+name: $projectName
+description: A Dartango web application
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  dartango:
+    path: ../dartango
+  shelf: ^1.4.0
+  args: ^2.4.0
+  path: ^1.8.0
+
+dev_dependencies:
+  test: ^1.24.0
+  lints: ^3.0.0
+''';
+
+    await File(path.join(outputPath, 'pubspec.yaml')).writeAsString(pubspecContent);
+  }
+
+  Future<void> _generateMainFile() async {
+    final mainContent = '''
+import 'package:dartango/dartango.dart';
+import 'package:$projectName/app.dart';
+
+Future<void> main(List<String> args) async {
+  final app = ${_toPascalCase(projectName)}App();
+  await app.run(args);
+}
+''';
+
+    final binDir = Directory(path.join(outputPath, 'bin'));
+    await binDir.create(recursive: true);
+    await File(path.join(binDir.path, 'main.dart')).writeAsString(mainContent);
+  }
+
+  Future<void> _generateLibFiles() async {
+    final libDir = Directory(path.join(outputPath, 'lib'));
+    await libDir.create(recursive: true);
+
+    // Generate main app file
+    final appContent = '''
+import 'package:dartango/dartango.dart';
+
+class ${_toPascalCase(projectName)}App extends DartangoApp {
+  @override
+  void configure() {
+    // Configure your application here
+    super.configure();
+  }
+  
+  @override
+  List<String> get installedApps => [
+    // Add your apps here
+  ];
+  
+  @override
+  Map<String, dynamic> get settings => {
+    'DEBUG': true,
+    'SECRET_KEY': 'your-secret-key-here',
+    'ALLOWED_HOSTS': ['localhost', '127.0.0.1'],
+  };
+}
+''';
+
+    await File(path.join(libDir.path, 'app.dart')).writeAsString(appContent);
+
+    // Generate URLs file
+    final urlsContent = '''
+import 'package:dartango/dartango.dart';
+
+final urlPatterns = [
+  path('/', HomeView.asView(), name: 'home'),
+  // Add more URL patterns here
+];
+''';
+
+    await File(path.join(libDir.path, 'urls.dart')).writeAsString(urlsContent);
+
+    // Generate basic view
+    final viewsContent = '''
+import 'package:dartango/dartango.dart';
+
+class HomeView extends TemplateView {
+  @override
+  String get templateName => 'home.html';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': 'Welcome to $projectName',
+      'message': 'Your Dartango application is running!',
+    };
+  }
+}
+''';
+
+    await File(path.join(libDir.path, 'views.dart')).writeAsString(viewsContent);
+  }
+
+  Future<void> _generateTestFiles() async {
+    final testDir = Directory(path.join(outputPath, 'test'));
+    await testDir.create(recursive: true);
+
+    final testContent = '''
+import 'package:test/test.dart';
+import 'package:$projectName/app.dart';
+
+void main() {
+  group('${_toPascalCase(projectName)}App', () {
+    late ${_toPascalCase(projectName)}App app;
+
+    setUp(() {
+      app = ${_toPascalCase(projectName)}App();
+    });
+
+    test('should create app instance', () {
+      expect(app, isNotNull);
+    });
+
+    test('should have correct settings', () {
+      expect(app.settings['DEBUG'], isTrue);
+    });
+  });
+}
+''';
+
+    await File(path.join(testDir.path, 'app_test.dart')).writeAsString(testContent);
+  }
+
+  Future<void> _generateConfigFiles() async {
+    // Generate analysis options
+    final analysisContent = '''
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+  
+linter:
+  rules:
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - avoid_print
+''';
+
+    await File(path.join(outputPath, 'analysis_options.yaml')).writeAsString(analysisContent);
+  }
+
+  Future<void> _generateDocumentation() async {
+    final readmeContent = '''
+# $projectName
+
+A Dartango web application.
+
+## Getting Started
+
+This project is built with [Dartango](https://github.com/yourusername/dartango), a Django-inspired web framework for Dart.
+
+### Prerequisites
+
+- Dart SDK 3.0.0 or higher
+- Dartango CLI
+
+### Installation
+
+1. Clone the repository
+2. Install dependencies:
+   ```bash
+   dart pub get
+   ```
+
+### Running the Application
+
+To start the development server:
+
+```bash
+dartango serve
+```
+
+The application will be available at `http://localhost:8000`.
+
+### Building for Production
+
+To build the application for production:
+
+```bash
+dartango build
+```
+
+### Testing
+
+To run tests:
+
+```bash
+dartango test
+```
+
+### Project Structure
+
+```
+$projectName/
+├── bin/
+│   └── main.dart          # Application entry point
+├── lib/
+│   ├── app.dart           # Main application class
+│   ├── urls.dart          # URL configuration
+│   └── views.dart         # View controllers
+├── test/                  # Test files
+├── static/                # Static assets
+├── templates/             # HTML templates
+└── pubspec.yaml          # Project configuration
+```
+
+### Commands
+
+- `dartango serve` - Start development server
+- `dartango build` - Build for production
+- `dartango test` - Run tests
+- `dartango generate` - Generate code scaffolding
+- `dartango doctor` - Check project health
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Submit a pull request
+
+## License
+
+This project is licensed under the MIT License.
+''';
+
+    await File(path.join(outputPath, 'README.md')).writeAsString(readmeContent);
+
+    final changelogContent = '''
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Initial project setup
+- Basic Dartango application structure
+
+## [1.0.0] - ${DateTime.now().toIso8601String().split('T')[0]}
+
+### Added
+- Initial release
+- Basic web application functionality
+''';
+
+    await File(path.join(outputPath, 'CHANGELOG.md')).writeAsString(changelogContent);
+  }
+
+  Future<void> _generateGitIgnore() async {
+    final gitignoreContent = '''
+# Dart
+.dart_tool/
+.packages
+pubspec.lock
+build/
+.pub-cache/
+.pub/
+
+# IDE
+.vscode/
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Application specific
+logs/
+data/
+uploads/
+coverage/
+.env
+config/local.yaml
+''';
+
+    await File(path.join(outputPath, '.gitignore')).writeAsString(gitignoreContent);
+  }
+
+  Future<void> _generateDefaultTemplate() async {
+    // Generate templates directory
+    final templatesDir = Directory(path.join(outputPath, 'templates'));
+    await templatesDir.create(recursive: true);
+
+    final homeTemplate = '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            text-align: center;
+            color: white;
+            max-width: 600px;
+            padding: 2rem;
+        }
+        h1 {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+        }
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin-top: 2rem;
+        }
+        .feature {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 1rem;
+            border-radius: 8px;
+            backdrop-filter: blur(10px);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{{ title }}</h1>
+        <p>{{ message }}</p>
+        
+        <div class="features">
+            <div class="feature">
+                <h3>🚀 Fast Development</h3>
+                <p>Get started quickly with Django-inspired patterns</p>
+            </div>
+            <div class="feature">
+                <h3>🎯 Type Safe</h3>
+                <p>Built with Dart for compile-time safety</p>
+            </div>
+            <div class="feature">
+                <h3>🔧 Flexible</h3>
+                <p>Customize every aspect of your application</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+''';
+
+    await File(path.join(templatesDir.path, 'home.html')).writeAsString(homeTemplate);
+
+    // Generate static directory
+    final staticDir = Directory(path.join(outputPath, 'static'));
+    await staticDir.create(recursive: true);
+    
+    final cssDir = Directory(path.join(staticDir.path, 'css'));
+    await cssDir.create(recursive: true);
+    
+    final jsDir = Directory(path.join(staticDir.path, 'js'));
+    await jsDir.create(recursive: true);
+  }
+
+  Future<void> _generateMinimalTemplate() async {
+    // Minimal template with just basic structure
+    final templatesDir = Directory(path.join(outputPath, 'templates'));
+    await templatesDir.create(recursive: true);
+
+    final minimalTemplate = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <p>{{ message }}</p>
+</body>
+</html>
+''';
+
+    await File(path.join(templatesDir.path, 'home.html')).writeAsString(minimalTemplate);
+  }
+
+  Future<void> _generateApiOnlyTemplate() async {
+    // Generate API-specific files
+    final libDir = Directory(path.join(outputPath, 'lib'));
+    
+    // Override the views file for API
+    final apiViewsContent = '''
+import 'package:dartango/dartango.dart';
+
+class ApiView extends View {
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    return JsonResponse({
+      'message': 'Welcome to $projectName API',
+      'version': '1.0.0',
+      'endpoints': [
+        '/api/v1/health',
+        '/api/v1/status',
+      ],
+    });
+  }
+}
+
+class HealthView extends View {
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    return JsonResponse({
+      'status': 'healthy',
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+  }
+}
+''';
+
+    await File(path.join(libDir.path, 'views.dart')).writeAsString(apiViewsContent);
+
+    // Override URLs for API
+    final apiUrlsContent = '''
+import 'package:dartango/dartango.dart';
+
+final urlPatterns = [
+  path('/', ApiView.asView(), name: 'api_root'),
+  path('/health', HealthView.asView(), name: 'health'),
+  // Add more API endpoints here
+];
+''';
+
+    await File(path.join(libDir.path, 'urls.dart')).writeAsString(apiUrlsContent);
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+}

--- a/packages/dartango_cli/lib/src/generators/view_generator.dart
+++ b/packages/dartango_cli/lib/src/generators/view_generator.dart
@@ -1,0 +1,578 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class ViewGenerator {
+  final String name;
+  final String app;
+  final String outputPath;
+  final bool force;
+
+  ViewGenerator({
+    required this.name,
+    required this.app,
+    required this.outputPath,
+    this.force = false,
+  });
+
+  Future<void> generate() async {
+    final viewsDir = Directory(outputPath);
+    await viewsDir.create(recursive: true);
+
+    final viewFileName = '${_toSnakeCase(name)}.dart';
+    final viewFile = File(path.join(viewsDir.path, viewFileName));
+
+    if (await viewFile.exists() && !force) {
+      throw Exception('View file already exists: ${viewFile.path}');
+    }
+
+    final viewContent = _generateViewContent();
+    await viewFile.writeAsString(viewContent);
+
+    // Generate corresponding template
+    await _generateTemplate();
+  }
+
+  String _generateViewContent() {
+    final className = _toPascalCase(name);
+    final templateName = '${app}/${_toSnakeCase(name)}.html';
+
+    return '''
+import 'package:dartango/dartango.dart';
+
+// Function-based view
+Future<HttpResponse> ${_toCamelCase(name)}(HttpRequest request) async {
+  final context = {
+    'title': '${_toTitleCase(name)}',
+    'app_name': '$app',
+    'timestamp': DateTime.now().toIso8601String(),
+  };
+  
+  return TemplateResponse(request, '$templateName', context);
+}
+
+// Class-based view
+class $className extends TemplateView {
+  @override
+  String get templateName => '$templateName';
+  
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    final context = await getContextData();
+    return TemplateResponse(request, templateName, context);
+  }
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(name)}',
+      'app_name': '$app',
+      'view_name': '$name',
+      'timestamp': DateTime.now().toIso8601String(),
+      ...super.getContextData(),
+    };
+  }
+}
+
+// API view variant
+class ${className}ApiView extends View {
+  @override
+  Future<HttpResponse> get(HttpRequest request) async {
+    final data = {
+      'message': 'Hello from ${_toTitleCase(name)} API',
+      'app': '$app',
+      'view': '$name',
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    
+    return JsonResponse(data);
+  }
+  
+  @override
+  Future<HttpResponse> post(HttpRequest request) async {
+    final body = await request.json();
+    
+    // Process the request data
+    final result = await _processData(body);
+    
+    return JsonResponse({
+      'success': true,
+      'data': result,
+      'message': 'Data processed successfully',
+    });
+  }
+  
+  Future<Map<String, dynamic>> _processData(Map<String, dynamic> data) async {
+    // Implement your data processing logic here
+    return {
+      'processed_at': DateTime.now().toIso8601String(),
+      'input': data,
+    };
+  }
+}
+
+// List view for displaying multiple items
+class ${className}ListView extends ListView {
+  @override
+  String get templateName => '${app}/${_toSnakeCase(name)}_list.html';
+  
+  @override
+  Future<QuerySet> getQuerySet() async {
+    // Return your model queryset here
+    // Example: return YourModel.objects.all();
+    return Future.value(QuerySet([]));
+  }
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(name)} List',
+      'app_name': '$app',
+      ...super.getContextData(),
+    };
+  }
+}
+
+// Detail view for displaying single item
+class ${className}DetailView extends DetailView {
+  @override
+  String get templateName => '${app}/${_toSnakeCase(name)}_detail.html';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(name)} Detail',
+      'app_name': '$app',
+      ...super.getContextData(),
+    };
+  }
+}
+
+// Create view for creating new items
+class ${className}CreateView extends CreateView {
+  @override
+  String get templateName => '${app}/${_toSnakeCase(name)}_form.html';
+  
+  @override
+  String get successUrl => '/$app/${_toSnakeCase(name)}/';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': 'Create ${_toTitleCase(name)}',
+      'app_name': '$app',
+      'form_action': 'create',
+      ...super.getContextData(),
+    };
+  }
+}
+
+// Update view for editing existing items
+class ${className}UpdateView extends UpdateView {
+  @override
+  String get templateName => '${app}/${_toSnakeCase(name)}_form.html';
+  
+  @override
+  String get successUrl => '/$app/${_toSnakeCase(name)}/';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': 'Update ${_toTitleCase(name)}',
+      'app_name': '$app',
+      'form_action': 'update',
+      ...super.getContextData(),
+    };
+  }
+}
+
+// Delete view for removing items
+class ${className}DeleteView extends DeleteView {
+  @override
+  String get templateName => '${app}/${_toSnakeCase(name)}_confirm_delete.html';
+  
+  @override
+  String get successUrl => '/$app/${_toSnakeCase(name)}/';
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': 'Delete ${_toTitleCase(name)}',
+      'app_name': '$app',
+      ...super.getContextData(),
+    };
+  }
+}
+
+// Custom mixin for additional functionality
+mixin ${className}Mixin {
+  Future<bool> hasPermission(HttpRequest request) async {
+    // Implement your permission logic here
+    return true;
+  }
+  
+  Future<void> logAccess(HttpRequest request) async {
+    // Implement your logging logic here
+    print('Access to ${_toTitleCase(name)} by \${request.remoteAddr}');
+  }
+}
+
+// View with custom permissions
+class ${className}PermissionView extends TemplateView with ${className}Mixin {
+  @override
+  String get templateName => '$templateName';
+  
+  @override
+  Future<HttpResponse> dispatch(HttpRequest request) async {
+    if (!await hasPermission(request)) {
+      return HttpResponse.forbidden('Permission denied');
+    }
+    
+    await logAccess(request);
+    return super.dispatch(request);
+  }
+  
+  @override
+  Map<String, dynamic> getContextData() {
+    return {
+      'title': '${_toTitleCase(name)} (Protected)',
+      'app_name': '$app',
+      ...super.getContextData(),
+    };
+  }
+}
+''';
+  }
+
+  Future<void> _generateTemplate() async {
+    final templatesDir = Directory(path.join(outputPath, '..', 'templates', app));
+    await templatesDir.create(recursive: true);
+
+    final templateFileName = '${_toSnakeCase(name)}.html';
+    final templateFile = File(path.join(templatesDir.path, templateFileName));
+
+    if (await templateFile.exists() && !force) {
+      return; // Don't overwrite existing templates
+    }
+
+    final templateContent = _generateTemplateContent();
+    await templateFile.writeAsString(templateContent);
+
+    // Generate additional template variants
+    await _generateListTemplate(templatesDir);
+    await _generateDetailTemplate(templatesDir);
+    await _generateFormTemplate(templatesDir);
+    await _generateDeleteTemplate(templatesDir);
+  }
+
+  String _generateTemplateContent() {
+    return '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="header">
+        <h1>{{ title }}</h1>
+        <p class="subtitle">Welcome to the ${_toTitleCase(name)} view</p>
+    </div>
+    
+    <div class="content">
+        <div class="info-card">
+            <h3>View Information</h3>
+            <ul>
+                <li><strong>App:</strong> {{ app_name }}</li>
+                <li><strong>View:</strong> {{ view_name }}</li>
+                <li><strong>Generated:</strong> {{ timestamp }}</li>
+            </ul>
+        </div>
+        
+        <div class="actions">
+            <a href="/" class="btn btn-secondary">Home</a>
+            <a href="/{{ app_name }}/" class="btn btn-primary">{{ app_name|title }} Home</a>
+        </div>
+    </div>
+</div>
+
+<style>
+    .container {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+    
+    .header {
+        text-align: center;
+        margin-bottom: 2rem;
+    }
+    
+    .header h1 {
+        color: #333;
+        margin-bottom: 0.5rem;
+    }
+    
+    .subtitle {
+        color: #666;
+        font-size: 1.1rem;
+    }
+    
+    .info-card {
+        background: #f8f9fa;
+        padding: 1.5rem;
+        border-radius: 8px;
+        margin-bottom: 2rem;
+    }
+    
+    .info-card h3 {
+        margin-top: 0;
+        color: #495057;
+    }
+    
+    .info-card ul {
+        list-style: none;
+        padding: 0;
+    }
+    
+    .info-card li {
+        padding: 0.25rem 0;
+    }
+    
+    .actions {
+        text-align: center;
+    }
+    
+    .btn {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        margin: 0 0.5rem;
+        text-decoration: none;
+        border-radius: 4px;
+        font-weight: 500;
+    }
+    
+    .btn-primary {
+        background: #007bff;
+        color: white;
+    }
+    
+    .btn-secondary {
+        background: #6c757d;
+        color: white;
+    }
+    
+    .btn:hover {
+        opacity: 0.9;
+    }
+</style>
+{% endblock %}
+''';
+  }
+
+  Future<void> _generateListTemplate(Directory templatesDir) async {
+    final listTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="header">
+        <h1>{{ title }}</h1>
+        <div class="actions">
+            <a href="create/" class="btn btn-primary">Create New</a>
+        </div>
+    </div>
+    
+    <div class="list-container">
+        {% for item in object_list %}
+        <div class="list-item">
+            <h3>
+                <a href="{{ item.id }}/">{{ item.name }}</a>
+            </h3>
+            <p>{{ item.description }}</p>
+            <div class="item-meta">
+                <span>Created: {{ item.created_at }}</span>
+                <span>Status: {{ item.is_active|yesno:"Active,Inactive" }}</span>
+            </div>
+        </div>
+        {% empty %}
+        <div class="empty-state">
+            <p>No items found.</p>
+            <a href="create/" class="btn btn-primary">Create the first one</a>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${_toSnakeCase(name)}_list.html')).writeAsString(listTemplate);
+  }
+
+  Future<void> _generateDetailTemplate(Directory templatesDir) async {
+    final detailTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="header">
+        <h1>{{ object.name }}</h1>
+        <div class="actions">
+            <a href="../" class="btn btn-secondary">Back to List</a>
+            <a href="edit/" class="btn btn-primary">Edit</a>
+            <a href="delete/" class="btn btn-danger">Delete</a>
+        </div>
+    </div>
+    
+    <div class="detail-container">
+        <div class="detail-card">
+            <h3>Details</h3>
+            <dl>
+                <dt>Name</dt>
+                <dd>{{ object.name }}</dd>
+                
+                <dt>Description</dt>
+                <dd>{{ object.description|default:"No description" }}</dd>
+                
+                <dt>Status</dt>
+                <dd>{{ object.is_active|yesno:"Active,Inactive" }}</dd>
+                
+                <dt>Created</dt>
+                <dd>{{ object.created_at }}</dd>
+                
+                <dt>Last Updated</dt>
+                <dd>{{ object.updated_at }}</dd>
+            </dl>
+        </div>
+    </div>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${_toSnakeCase(name)}_detail.html')).writeAsString(detailTemplate);
+  }
+
+  Future<void> _generateFormTemplate(Directory templatesDir) async {
+    final formTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="header">
+        <h1>{{ title }}</h1>
+    </div>
+    
+    <form method="post" class="form-container">
+        {% csrf_token %}
+        
+        <div class="form-group">
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" 
+                   value="{{ form.name.value|default:'' }}" 
+                   class="form-control" required>
+            {% if form.name.errors %}
+                <div class="error">{{ form.name.errors }}</div>
+            {% endif %}
+        </div>
+        
+        <div class="form-group">
+            <label for="description">Description:</label>
+            <textarea id="description" name="description" 
+                      class="form-control" rows="4">{{ form.description.value|default:'' }}</textarea>
+            {% if form.description.errors %}
+                <div class="error">{{ form.description.errors }}</div>
+            {% endif %}
+        </div>
+        
+        <div class="form-group">
+            <label>
+                <input type="checkbox" name="is_active" 
+                       {% if form.is_active.value %}checked{% endif %}>
+                Active
+            </label>
+            {% if form.is_active.errors %}
+                <div class="error">{{ form.is_active.errors }}</div>
+            {% endif %}
+        </div>
+        
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">
+                {% if form_action == 'create' %}Create{% else %}Update{% endif %}
+            </button>
+            <a href="../" class="btn btn-secondary">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${_toSnakeCase(name)}_form.html')).writeAsString(formTemplate);
+  }
+
+  Future<void> _generateDeleteTemplate(Directory templatesDir) async {
+    final deleteTemplate = '''
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="header">
+        <h1>{{ title }}</h1>
+    </div>
+    
+    <div class="delete-container">
+        <div class="warning-card">
+            <h3>⚠️ Are you sure?</h3>
+            <p>Are you sure you want to delete "<strong>{{ object.name }}</strong>"?</p>
+            <p class="warning">This action cannot be undone.</p>
+        </div>
+        
+        <form method="post" class="delete-form">
+            {% csrf_token %}
+            <div class="form-actions">
+                <button type="submit" class="btn btn-danger">Yes, Delete</button>
+                <a href="../" class="btn btn-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+''';
+
+    await File(path.join(templatesDir.path, '${_toSnakeCase(name)}_confirm_delete.html')).writeAsString(deleteTemplate);
+  }
+
+  String _toPascalCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join('');
+  }
+
+  String _toCamelCase(String input) {
+    final parts = input.split('_');
+    if (parts.isEmpty) return input;
+    
+    return parts.first.toLowerCase() + 
+           parts.skip(1).map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '').join('');
+  }
+
+  String _toSnakeCase(String input) {
+    return input
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => '_${match.group(1)!.toLowerCase()}')
+        .replaceFirst(RegExp(r'^_'), '')
+        .toLowerCase();
+  }
+
+  String _toTitleCase(String input) {
+    return input
+        .split('_')
+        .map((word) => word.isNotEmpty ? word[0].toUpperCase() + word.substring(1) : '')
+        .join(' ');
+  }
+}


### PR DESCRIPTION
## Summary
- Add complete CLI runner with command management system
- Implement create, startapp, generate, serve, build, test, doctor commands
- Create comprehensive code generators for projects, apps, models, views, middleware, commands
- Support multiple project templates (default, minimal, api-only)
- Add Django-compatible command structure and workflows
- Include project scaffolding with pubspec, templates, and directory structure

## Test plan
- [ ] Test project creation with different templates
- [ ] Verify app generation and scaffolding
- [ ] Test code generators for models, views, middleware, commands
- [ ] Validate CLI command functionality
- [ ] Test development server and build system
- [ ] Verify doctor command diagnostics